### PR TITLE
Add user message create, read, update, delete and quote functionality

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -1,0 +1,80 @@
+import models from '../models';
+
+class Message {
+  constructor() {
+    this.messageModel = models.message;
+  }
+
+  async createMessage(messageDetails) {
+    const newMessage = { ...messageDetails };
+    const { senderId, receiverId } = newMessage;
+    if (senderId === receiverId) {
+      const error = new Error('sender and receiver Id cannot be the same');
+      error.code = 422;
+      throw error;
+    }
+    if (newMessage.quoteId) {
+      const message = await this.messageModel.findOne({ where: { id: newMessage.quoteId } });
+      if (!message) {
+        const error = new Error('message to be quoted was not found');
+        error.code = 404;
+        throw error;
+      }
+      newMessage.quote = true;
+    }
+    const message = await this.messageModel.create(newMessage);
+    return message;
+  }
+
+  async updateMessage(messageDetails) {
+    const { userId, messageId, text } = messageDetails;
+    const message = await this.messageModel.findOne({ where: { id: messageId } });
+    if (!message) {
+      const error = new Error('message was not found');
+      error.code = 404;
+      throw error;
+    }
+    if (message.senderId !== userId) {
+      const error = new Error('unable to update message of another user');
+      error.code = 422;
+      throw error;
+    }
+    return message.update({ text, edited: true });
+  }
+
+  async getMessage({ messageId, quote }) {
+    const message = await this.messageModel.findOne({ where: { id: messageId } });
+    if (!message) {
+      if (quote) {
+        return [];
+      }
+      const error = new Error('message was not found');
+      error.code = 404;
+      throw error;
+    }
+    return [message];
+  }
+
+  async getMessages({ senderId, receiverId }) {
+    const messages = await this.messageModel.findAll({ where: { senderId, receiverId }, order: [['createdAt']] });
+    return messages;
+  }
+
+  async deleteMessage({ messageId, userId }) {
+    const message = await this.messageModel.findOne({ where: { id: messageId } });
+    if (!message) {
+      const error = new Error('message was not found');
+      error.code = 404;
+      throw error;
+    }
+    if (message.senderId !== userId) {
+      const error = new Error('unable to delete message of another user');
+      error.code = 422;
+      throw error;
+    }
+    await message.destroy(messageId);
+    return true;
+  }
+}
+
+export default Message;

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -11,6 +11,11 @@ class User {
     this.userModel = models.user;
   }
 
+  async getSingleUser(userId) {
+    const user = await this.userModel.findOne({ where: { id: userId } });
+    return user;
+  }
+
   async signin(userDetails) {
     const { email, password } = userDetails;
     const user = await this.userModel.findOne({ where: { email } });

--- a/migrations/20191118163448-create-message.js
+++ b/migrations/20191118163448-create-message.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('messages', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      text: {
+        type: Sequelize.STRING
+      },
+      edited: {
+        type: Sequelize.BOOLEAN
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('messages');
+  }
+};

--- a/migrations/20191118171233-add-senderid-receiverid-to-message.js
+++ b/migrations/20191118171233-add-senderid-receiverid-to-message.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return [
+      await queryInterface.addColumn(
+        'messages',
+        'senderId',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: {
+            model: 'users',
+            key: "id",
+          }
+        }
+      ),
+      await queryInterface.addColumn(
+        'messages',
+        'receiverId',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: {
+            model: 'users',
+            key: "id",
+          }
+        }
+      ),
+    ];
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return [
+      await queryInterface.removeColumn('messages', 'senderId'),
+      await queryInterface.removeColumn('messages', 'receiverId'),
+    ];
+  }
+};

--- a/migrations/20191119162613-add-quoteid-quote-to-message.js
+++ b/migrations/20191119162613-add-quoteid-quote-to-message.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return [
+      await queryInterface.addColumn(
+        'messages',
+        'quoteId',
+        {
+          type: Sequelize.INTEGER,
+          references: {
+            model: 'messages',
+            key: "id",
+          },
+          onDelete: 'SET NULL',
+        }
+      ),
+      await queryInterface.addColumn(
+        'messages',
+        'quote',
+        {
+          type: Sequelize.BOOLEAN,
+          allowNull: false,
+        }
+      ),
+    ]
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return [
+      queryInterface.removeColumn('messages', 'quoteId'),
+      queryInterface.removeColumn('messages', 'quote')
+    ]
+  }
+};

--- a/models/message.js
+++ b/models/message.js
@@ -1,0 +1,32 @@
+module.exports = (sequelize, DataTypes) => {
+  const message = sequelize.define('message', {
+    text: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      min: 1,
+    },
+    edited: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    quote: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+  });
+  message.associate = (models) => {
+    message.belongsTo(models.user, {
+      foreignKey: 'senderId',
+      as: 'sender',
+    });
+    message.belongsTo(models.user, {
+      foreignKey: 'receiverId',
+      as: 'receiver',
+    });
+    message.belongsTo(models.message, {
+      foreignKey: 'quoteId',
+      onDelete: 'set null',
+    });
+  };
+  return message;
+};

--- a/resolvers/message.js
+++ b/resolvers/message.js
@@ -1,0 +1,52 @@
+import MessageController from '../controllers/messageController';
+import UserController from '../controllers/userController';
+import { isAuth } from '../middleware/authentication';
+
+const resolvers = {
+  Message: {
+    sender: (parent) => {
+      const userController = new UserController();
+      return userController.getSingleUser(parent.senderId);
+    },
+    receiver: (parent) => {
+      const userController = new UserController();
+      return userController.getSingleUser(parent.receiverId);
+    },
+    quote: (parent) => {
+      const messageController = new MessageController();
+      return messageController.getMessage({ messageId: parent.quoteId, quote: true });
+    },
+  },
+  Query: {
+    getMessages: (parent, { receiverId }, { user }) => {
+      isAuth(user);
+      const messageController = new MessageController();
+      return messageController.getMessages({ receiverId, senderId: user.userId });
+    },
+  },
+  Mutation: {
+    createMessage: (parent, messageDetails, { user }) => {
+      isAuth(user);
+      const messageController = new MessageController();
+      return messageController.createMessage({
+        ...messageDetails,
+        senderId: user.userId,
+      });
+    },
+    updateMessage: (parent, messageDetails, { user }) => {
+      isAuth(user);
+      const messageController = new MessageController();
+      return messageController.updateMessage({
+        ...messageDetails,
+        userId: user.userId,
+      });
+    },
+    deleteMessage: (parent, { messageId }, { user }) => {
+      isAuth(user);
+      const messageController = new MessageController();
+      return messageController.deleteMessage({ messageId, userId: user.userId });
+    },
+  },
+};
+
+export default resolvers;

--- a/schema/message.js
+++ b/schema/message.js
@@ -1,0 +1,24 @@
+import { gql } from 'apollo-server-express';
+
+const typeDefs = gql`
+  type Message {
+    id: Int!
+    text: String!
+    edited: Boolean
+    sender: User!
+    receiver: User
+    quote: [Message]!
+  }
+
+  type Query {
+    getMessages(receiverId: Int!): [Message]!
+  }
+
+  type Mutation {
+    createMessage(text: String!, receiverId: Int, quoteId: Int): Message!
+    updateMessage(text: String!, messageId: Int!): Message!
+    deleteMessage(messageId: Int!): Boolean!
+  }
+`;
+
+export default typeDefs;

--- a/tests/message.test.js
+++ b/tests/message.test.js
@@ -1,0 +1,76 @@
+import models from '../models';
+import MessageController from '../controllers/messageController';
+import { resetDB, closeDbConnection } from './helpers/testDbHelper';
+
+describe('message controller', () => {
+  let userOneId
+  let userTwoId
+  beforeAll(async (done) => {
+    const userOne = await models.user.create({
+      username: 'userOne',
+      email: 'userOne@gmail.com',
+      password: 'userPassword',
+    });
+    const userTwo = await models.user.create({
+      username: 'userTwo',
+      email: 'userTwo@gmail.com',
+      password: 'userPassword',
+    });
+    userOneId = userOne.dataValues.id
+    userTwoId = userTwo.dataValues.id
+    done();
+  });
+
+  afterAll(async (done) => {
+    await resetDB();
+    await closeDbConnection();
+    done();
+  });
+
+  it('should create, get, update and delete a message', async (done) => {
+    // create user message
+    const messageController = new MessageController();
+    const message = await messageController.createMessage({
+      text: 'This is the text',
+      receiverId: userTwoId,
+      senderId: userOneId,
+    });
+    expect(message.text).toEqual('This is the text');
+
+    // update user message
+    const updatedMessage = await messageController.updateMessage({
+      text: 'This is the updated text',
+      messageId: message.id,
+      userId: userOneId
+    });
+    expect(updatedMessage.text).toEqual('This is the updated text');
+
+    // get user message
+    const singleMessage = await messageController.getMessage({ messageId: message.id });
+    expect(singleMessage[0].text).toEqual('This is the updated text');
+
+    // get list of user messages
+    const messages = await messageController.getMessages({ 
+      senderId: userOneId, 
+      receiverId: userTwoId 
+    });
+    expect(messages.length).toEqual(1);
+
+    // quote a user message
+    const secondMessageWithQuote = await messageController.createMessage({
+      text: 'This is the text for the message with quote',
+      quoteId: message.id,
+      receiverId: userTwoId,
+      senderId: userOneId,
+    });
+    expect(secondMessageWithQuote.quoteId).toEqual(message.id);
+
+    // delete user message
+    const deletedSuccessfully = await messageController.deleteMessage({ 
+      messageId: message.id, 
+      userId: userOneId 
+    });
+    expect(deletedSuccessfully).toBeTruthy();
+    done();
+  });
+});


### PR DESCRIPTION
### What does this PR do?
This pull requests implements the user message create, read, update, delete and quote functionality

#### Description of Task to be completed?
- Enable users to send a message to another user
- Enable user to get a list of messages sent to another user
- Enable a user to update a particular message
- Enable a user to delete a message
- Enable a user to quote another message

#### How should this be manually tested?
- Setup the application
- Navigate to `http://localhost:4000/graphql` using a browser of your choice
- Write a mutation to signup two users
- Create a message, update, delete, get and quote messages

#### What are the relevant pivotal tracker stories?
[A user should be able to send and receive a text-based message](https://trello.com/c/ywEuMSrq/14-a-user-should-be-able-to-send-and-receive-a-text-based-message)